### PR TITLE
Fixing guild config update task

### DIFF
--- a/front/update.guild.config.task.js
+++ b/front/update.guild.config.task.js
@@ -15,6 +15,7 @@ let unit = module.exports = {
         } catch (error) {
             await errorsLogging.save(error);
             embedHelper.error(message.channel);
+            return guildsParameters;
         }
     }
 }


### PR DESCRIPTION
The function should return guilds settings when a parsing error occurs.